### PR TITLE
Update the Dependency Version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
     "export": "next export"
   },
   "dependencies": {
-    "classnames": "^2.3.1",
-    "next": "10.1.3",
-    "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "classnames": "^2.3.2",
+    "next": "13.2.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.2.5",
-    "postcss": "^8.2.9",
+    "postcss": "^8.4.21",
     "tailwindcss": "^2.1.1"
   }
 }


### PR DESCRIPTION
## Error

Error when running ``npm run dev``

```bash
info  - Using webpack 4. Reason: future.webpack5 option not enabled https://nextjs.org/docs/messages/webpack5
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/parser' is not defined by "exports" in D:\nauval-next\node_modules\next\node_modules\postcss\package.json
```

## Solution

Changed Some dependencies to stable version

```json
"dependencies": {
    "classnames": "^2.3.2",
    "next": "13.2.4",
    "react": "18.2.0",
    "react-dom": "18.2.0"
  },
  "devDependencies": {
    "autoprefixer": "^10.2.5",
    "postcss": "^8.4.21",
    "tailwindcss": "^2.1.1"
  }
```